### PR TITLE
fixed test for prmin_prmax and fixed definition for pr_max

### DIFF
--- a/switss/model/reachability_form.py
+++ b/switss/model/reachability_form.py
@@ -508,9 +508,9 @@ class ReachabilityForm:
         :return: Result vector
         :rtype: np.ndarray[float]
         """
-        N,C = self.__P.shape
-
         matr, rhs = self.fark_y_constraints(0)
+        N,C = matr.shape
+
         max_y_lp = LP.from_coefficients(
             matr,rhs,self.to_target,sense="<=",objective="max")
 
@@ -567,7 +567,7 @@ class ReachabilityForm:
         """
         C,N = self.__P.shape
 
-        matr, rhs = self.fark_z_constraints(0)
+        matr, rhs = self.fark_z_constraints(1)
         opt = np.ones(N)
         pr_max_z_lp = LP.from_coefficients(
             matr,rhs,opt,sense=">=",objective="min")

--- a/switss/model/reachability_form.py
+++ b/switss/model/reachability_form.py
@@ -508,7 +508,7 @@ class ReachabilityForm:
         :return: Result vector
         :rtype: np.ndarray[float]
         """
-        N,C = self.__P.shape
+        C,N = self.__P.shape
 
         matr, rhs = self.fark_y_constraints(0)
         max_y_lp = LP.from_coefficients(

--- a/switss/model/reachability_form.py
+++ b/switss/model/reachability_form.py
@@ -508,9 +508,9 @@ class ReachabilityForm:
         :return: Result vector
         :rtype: np.ndarray[float]
         """
-        matr, rhs = self.fark_y_constraints(0)
-        N,C = matr.shape
+        N,C = self.__P.shape
 
+        matr, rhs = self.fark_y_constraints(0)
         max_y_lp = LP.from_coefficients(
             matr,rhs,self.to_target,sense="<=",objective="max")
 

--- a/switss/test/test_dtmc.py
+++ b/switss/test/test_dtmc.py
@@ -101,18 +101,18 @@ def test_prmin_prmax():
             m_y_st = reach_form.max_y_state(solver=solver)
 
             for vec in [m_z_st,m_z_st_act,m_y_st,m_y_st_act]:
-                assert (vec >= 0).all
+                assert (vec >= -1e-8).all()
 
             for vec in [m_z_st,m_z_st_act]:
-                assert (vec <= 1).all
+                assert (vec <= 1+1e-8).all()
 
             pr_min = reach_form.pr_min()
             pr_max = reach_form.pr_max()
 
             for vec in [pr_min,pr_max]:
-                assert (vec <= 1).all and (vec >= 0).all
+                assert (vec <= 1).all() and (vec >= 0).all()
 
-            assert (pr_min == pr_max).all
+            assert (pr_min == pr_max).all()
 
             pr_min_at_init = pr_min[reach_form.initial]
             pr_max_at_init = pr_max[reach_form.initial]

--- a/switss/test/test_dtmc.py
+++ b/switss/test/test_dtmc.py
@@ -119,9 +119,9 @@ def test_prmin_prmax():
 
             # we find farkas certificates for pr_min and pr_max
             fark_cert_min = generate_farkas_certificate(
-                reach_form,"min",">=",pr_min_at_init)
+                reach_form,"min",">=",pr_min_at_init - 1e-8)
             fark_cert_max = generate_farkas_certificate(
-                reach_form,"max",">=",pr_max_at_init)
+                reach_form,"max",">=",pr_max_at_init - 1e-8)
 
             assert (fark_cert_min is not None) and (fark_cert_max is not None)
 

--- a/switss/test/test_mdp.py
+++ b/switss/test/test_mdp.py
@@ -151,7 +151,7 @@ def test_prmin_prmax():
             m_y_st_act = reach_form.max_y_state_action(solver=solver)
             m_y_st = reach_form.max_y_state(solver=solver)
 
-            for idx,vec in enumerate([m_z_st,m_z_st_act,m_y_st,m_y_st_act]):
+            for vec in [m_z_st,m_z_st_act,m_y_st,m_y_st_act]:
                 assert (vec >= -1e-8).all()
 
             for vec in [m_z_st,m_z_st_act]:

--- a/switss/test/test_mdp.py
+++ b/switss/test/test_mdp.py
@@ -151,19 +151,19 @@ def test_prmin_prmax():
             m_y_st_act = reach_form.max_y_state_action(solver=solver)
             m_y_st = reach_form.max_y_state(solver=solver)
 
-            for vec in [m_z_st,m_z_st_act,m_y_st,m_y_st_act]:
-                assert (vec >= 0).all
+            for idx,vec in enumerate([m_z_st,m_z_st_act,m_y_st,m_y_st_act]):
+                assert (vec >= -1e-8).all()
 
             for vec in [m_z_st,m_z_st_act]:
-                assert (vec <= 1).all
+                assert (vec <= 1+1e-8).all()
 
             pr_min = reach_form.pr_min()
             pr_max = reach_form.pr_max()
 
             for vec in [pr_min,pr_max]:
-                assert (vec <= 1).all and (vec > 0).all
+                assert (vec <= 1).all() and (vec > 0).all()
 
-            assert (pr_min <= pr_max).all
+            assert (pr_min <= pr_max).all()
 
             pr_min_at_init = pr_min[reach_form.initial]
             pr_max_at_init = pr_max[reach_form.initial]


### PR DESCRIPTION
This fixes a mistake in the computation of Pr^max. Previously, Pr^max was computed using a solution to

    min sum_i z(i) subject to z in Mz >= r

where `Mz >= r` iff `Az >= b` and `z(init) <= 0`. The fix changes the last condition to `z(init) <= 1`, rendering `Mz >= r` equivalent to `Az >= b`, since `z(init) <= 1` by definition. This is also consistent with the definition of Pr^max in https://arxiv.org/pdf/1910.10636.pdf. May have an impact on heuristics/results?